### PR TITLE
解决Log类名冲突

### DIFF
--- a/Aliyun/Log/Client.php
+++ b/Aliyun/Log/Client.php
@@ -242,7 +242,7 @@ class Aliyun_Log_Client {
         $logGroup->setSource ( $source );
         $logitems = $request->getLogitems ();
         foreach ( $logitems as $logItem ) {
-            $log = new Log ();
+            $log = new Aliyun_Log ();
             $log->setTime ( $logItem->getTime () );
             $content = $logItem->getContents ();
             foreach ( $content as $key => $value ) {

--- a/Aliyun/Log/sls.proto.php
+++ b/Aliyun/Log/sls.proto.php
@@ -126,7 +126,7 @@ class Log_Content {
 }
 
 // message Log
-class Log {
+class Aliyun_Log {
   private $_unknown;
 
   function __construct($in = NULL, &$limit = PHP_INT_MAX) {


### PR DESCRIPTION
Log类跟PHP众多框架中类名冲突，现更换其名为Aliyun_Log。这样引入会避免冲突，更方便。