### PR TITLE
fix object of class CurlHadnle could not be converted to string issue

### DIFF
--- a/Aliyun/Log/requestcore.class.php
+++ b/Aliyun/Log/requestcore.class.php
@@ -832,7 +832,7 @@ class RequestCore
 
 		if ($this->response === false)
 		{
-			throw new RequestCore_Exception('cURL resource: ' . (string) $curl_handle . '; cURL error: ' . curl_error($curl_handle) . ' (' . curl_errno($curl_handle) . ')');
+			throw new RequestCore_Exception('cURL error: ' . curl_error($curl_handle) . ' (' . curl_errno($curl_handle) . ')');
 		}
 
 		$parsed_response = $this->process_response($curl_handle, $this->response);


### PR DESCRIPTION
When using the AliCloud logging sdk to dock logs, I found that the error message “Object of class CurlHandle could not be converted to string” would appear locally, and after some troubleshooting, I found that the requestcore.class. php file will be encountered when the return of the curl is empty false, this time on the fish curl_handle object for string conversion, in the conversion of the following error. But the error for the outer code if the direct use of exception can not be captured, this is a fatal error will affect the business operations, interrupt the business!

`
"exception": "Error: Object of class CurlHandle could not be converted to string in /app/vendor/alibabacloud/aliyun-log-php-sdk/Aliyun/Log/requestcore.class.php:835\nStack trace:\n#0 /app/vendor/alibabacloud/aliyun-log-php-sdk/Aliyun/Log/Client.php(142): RequestCore->send_request()\n#1 /app/vendor/alibabacloud/aliyun-log-php-sdk/Aliyun/Log/Client.php(157): 
`